### PR TITLE
Fix duplicate Engine blocks and file handle

### DIFF
--- a/interfaces/adfsuite/ams.py
+++ b/interfaces/adfsuite/ams.py
@@ -3061,6 +3061,33 @@ class AMSJob(SingleJob):
                 txtinp += system_block
 
             # and then engines
+            engine_counts: Dict[str, int] = {}
+            engine_original: Dict[str, str] = {}
+            for eng_key in input_settings:
+                if eng_key == ams:
+                    continue
+                eng_val = input_settings[eng_key]
+                if isinstance(eng_key, str) and eng_key.startswith("_"):
+                    if isinstance(eng_val, Settings) and "_h" in eng_val:
+                        header = str(eng_val["_h"])
+                        if header.lower().startswith("engine"):
+                            eng_name = header.split(None, 1)[1] if len(header.split(None, 1)) > 1 else header[6:]
+                        else:
+                            continue
+                    else:
+                        continue
+                else:
+                    eng_name = str(eng_key)
+
+                count = len(eng_val) if isinstance(eng_val, list) else 1
+                key_lc = eng_name.lower()
+                engine_original.setdefault(key_lc, eng_name)
+                engine_counts[key_lc] = engine_counts.get(key_lc, 0) + count
+
+            duplicate = next((engine_original[k] for k, c in engine_counts.items() if c > 1), None)
+            if duplicate:
+                raise ValueError(f"duplicate Engine block for {duplicate}")
+
             for engine in input_settings:
                 if engine != ams:
                     txtinp += "\n" + serialize("Engine " + engine, input_settings[engine], 0, end="EndEngine") + "\n"

--- a/scripts/coskf_batch.py
+++ b/scripts/coskf_batch.py
@@ -220,15 +220,16 @@ if __name__ == "__main__":
     workdir_root.mkdir(parents=True, exist_ok=True)
     coskf_dir.mkdir(parents=True, exist_ok=True)
 
-    for raw in open(args.smiles_file):
-        line = raw.strip()
-        if not line or line.startswith("#"):
-            continue
-        parts = line.split(None, 1)
-        smiles = parts[0]
-        name = (parts[1] if len(parts) > 1 else smiles).replace(" ", "_")
-        init(path=str(workdir_root), folder=name)
-        try:
-            process_molecule(smiles, name, args.nconfs)
-        finally:
-            finish()
+    with open(args.smiles_file) as fh:
+        for raw in fh:
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split(None, 1)
+            smiles = parts[0]
+            name = (parts[1] if len(parts) > 1 else smiles).replace(" ", "_")
+            init(path=str(workdir_root), folder=name)
+            try:
+                process_molecule(smiles, name, args.nconfs)
+            finally:
+                finish()

--- a/unit_tests/test_amsjob.py
+++ b/unit_tests/test_amsjob.py
@@ -1780,3 +1780,17 @@ License file: ./license.txt"""
         # Error in prerun
         job._error_msg = "RuntimeError: something went wrong"
         assert job.get_errormsg() == "RuntimeError: something went wrong"
+
+
+def test_get_input_raises_on_duplicate_engine_blocks():
+    settings = Settings()
+    settings.input.ams.Task = "SinglePoint"
+    block1 = Settings()
+    block2 = Settings()
+    settings.input.adf = [block1, block2]
+    mol = Molecule()
+    mol.add_atom(Atom(symbol="H", coords=(0, 0, 0)))
+    job = AMSJob(molecule=mol, settings=settings)
+
+    with pytest.raises(ValueError, match="duplicate Engine block for adf"):
+        job.get_input()


### PR DESCRIPTION
## Summary
- detect duplicate Engine blocks when serializing AMS input
- use a context manager for reading the SMILES file list
- test that duplicate Engine blocks raise an error

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68613f003994832aab406a298333ec1c